### PR TITLE
Add an omission option that allows you to specify the string at the end of the text.

### DIFF
--- a/jQuery.succinct.js
+++ b/jQuery.succinct.js
@@ -14,7 +14,8 @@
 	$.fn.succinct = function(size){
 
 		var defaults = {
-				size: 240
+				size: 240,
+				omission: '...'
 			},
 			options = $.extend(defaults, size);
 
@@ -32,7 +33,7 @@
 					if (textDefault.length > options.size) {
 						textTruncated = $.trim(textDefault).
 										substring(0, options.size).split(' ').
-										slice(0, -1).join(' ') + '...';
+										slice(0, -1).join(' ') + options.omission;
 
 						$(this).text(textTruncated);
 					}


### PR DESCRIPTION
By default, the omission is three dots (faux ellipses).

Use case: "The man in the barn unlocked the door to the animal cage. He continued to do this to several other random doors in town... (read more)"

Name of the "omission" option mimics Rails' truncate() method option of the same name - http://api.rubyonrails.org/classes/ActionView/Helpers/TextHelper.html#method-i-truncate
