### PR TITLE
Moved 'use strict' to live in the wrapper function so it won't interfere with concatenation.

### DIFF
--- a/jQuery.succinct.js
+++ b/jQuery.succinct.js
@@ -8,9 +8,9 @@
  */
 
  /*global jQuery*/
-'use strict';
-
 (function($){
+	'use strict';
+
 	$.fn.succinct = function(size){
 
 		var defaults = {


### PR DESCRIPTION
JSLint warns to use the function form of "use strict".
Moving it within the function wrapper helps to not interfere with other scripts when concatenating.

Ref. http://www.yuiblog.com/blog/2010/12/14/strict-mode-is-coming-to-town/
