### PR TITLE
Remove ugly chars from end with regex

### DIFF
--- a/jQuery.succinct.js
+++ b/jQuery.succinct.js
@@ -2,49 +2,65 @@
  * Copyright (c) 2013 Mike King (@micjamking)
  *
  * jQuery Succinct plugin
- * Version 1.0 (July 2013)
+ * Version 1.0.1 (July 2013)
  *
  * Licensed under the MIT License
  */
 
  /*global jQuery*/
 (function($){
-	'use strict';
+  'use strict';
 
-	$.fn.succinct = function(size){
+  $.fn.succinct = function(size){
 
-		var defaults = {
-				size: 240,
-				omission: '...'
-			},
-			options = $.extend(defaults, size);
+    var defaults = {
+        // length to reduce string to.
+        size: 240,
+        // suffix for the string once reduced.
+        omission: '...',
+        // regex of chars to remove if they are at end.
+        ignore: '\*\,\.\{\[\(\<\¦\¬\~\^'
+      },
+      options = $.extend(defaults, size);
 
-		return this.each(function(){
+    return this.each(function(){
 
-			var textDefault,
-				textTruncated,
-				elements = $(this);
+      var textDefault,
+        textTruncated,
+        r,
+        elements = $(this);
 
-			var truncate = function(){
+      var truncate = function(){
 
-				elements.each(function(){
-					textDefault = $(this).text();
+        elements.each(function(){
+          textDefault = $(this).text();
 
-					if (textDefault.length > options.size) {
-						textTruncated = $.trim(textDefault).
-										substring(0, options.size).split(' ').
-										slice(0, -1).join(' ') + options.omission;
+          if (textDefault.length > options.size) {
+            textTruncated = $.trim(textDefault).
+                    substring(0, options.size).split(' ').
+                    slice(0, -1).join(' ');
 
-						$(this).text(textTruncated);
-					}
-				});
-			};
 
-			var init = function() {
-				truncate();
-			};
+            if( options.ignore !== false ) {
+            
+              // create a regex based on the "ignore" option,
+              // these will be removed from end of string as they make
+              // succinct produce ugly results
+              r = new RegExp("[" + options.ignore + "]+$");
+              textTruncated = textTruncated.replace( r , "" );
+            
+            }
 
-			init();
-		});
-	};
+            $(this).text(textTruncated + options.omission);
+          }
+        });
+      };
+
+      var init = function() {
+        truncate();
+      };
+
+      init();
+    });
+  };
 })(jQuery);


### PR DESCRIPTION
I noticed in the demo (http://micjamking.github.io/succinct/) that if you use the character count as _**30**_ it leaves a "," at the end. this bothered me so i made a really simple addition that matches a regex at the end and removes characters like: 

*,.{[(<¦¬~^

this is set as an option so the user can change, remove or whatever. if set to 'false' it wont try to remove.
# 

Sorry about the tab/space issues.
not a lot really changed, but my IDE changed all the spacing.
