### PR TITLE
run trim() on html before assigning to textDefault

### DIFF
--- a/jQuery.succinct.js
+++ b/jQuery.succinct.js
@@ -27,7 +27,7 @@
 				regex    = /[!-\/:-@\[-`{-~]$/,
 				init     = function() {
 					elements.each(function() {
-						textDefault = $(this).html();
+						textDefault = $(this).html().trim();
 
 						if (textDefault.length > settings.size) {
 							textTruncated = $.trim(textDefault)


### PR DESCRIPTION
This causes my short strings with whitespaces to be truncated. Running a trim() before comparing string length and size setting fix that.